### PR TITLE
Add check for Azure credentials. CLI not needed [semver:patch]

### DIFF
--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -77,7 +77,7 @@ steps:
 
             We were unable to find a value for one or more of the following required environment variables:
             ---
-              AZURE_SUBSCRIPTION_ID 
+              AZURE_SUBSCRIPTION_ID
               AZURE_TENANT_ID
               AZURE_CLIENT_ID
               AZURE_CLIENT_SECRET

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -70,6 +70,25 @@ steps:
         }
         azure_Check () {
           output_Provider_Selected "Azure"
+          if [[ -z $AZURE_SUBSCRIPTION_ID || -z $AZURE_TENANT_ID || -z $AZURE_CLIENT_ID || -z $AZURE_CLIENT_SECRET ]]; then
+            echo "
+            ---
+            ERROR: No Azure credentials provided!
+
+            We were unable to find a value for one or more of the following required environment variables:
+            ---
+              AZURE_SUBSCRIPTION_ID 
+              AZURE_TENANT_ID
+              AZURE_CLIENT_ID
+              AZURE_CLIENT_SECRET
+            ---
+
+            The Serverless Framework needs access to Azure account credentials so that it can create and manage resources on your behalf.
+
+            Docs: https://serverless.com/framework/docs/providers/azure/guide/credentials/
+            "
+            exit 1
+          fi
         }
         tencent_Check () {
           output_Provider_Selected "Tencent"


### PR DESCRIPTION
Support to gracefully check for Azure credentials and supply documentation if not found.

Message:

```
 ERROR: No Azure credentials provided!

            We were unable to find a value for one or more of the following required environment variables:
            ---
              AZURE_SUBSCRIPTION_ID 
              AZURE_TENANT_ID
              AZURE_CLIENT_ID
              AZURE_CLIENT_SECRET
            ---

            The Serverless Framework needs access to Azure account credentials so that it can create and manage resources on your behalf.

            Docs: https://serverless.com/framework/docs/providers/azure/guide/credentials/
```

The Azure CLI orb is not suggested here (as it is for AWS) because it is not needed, the Serverless CLI will communicate with Azure directly via APIs and does not need any further configuration.

https://serverless.com/framework/docs/providers/azure/guide/credentials/


**Why Patch?**
I would like to add basic credential checking for each provider as a patch as it is not actually adding any functionality but instead providing a better experience in the event of failure.