### PR TITLE
[semver:patch] Changed serverless to serverless-framework for developer hub examples

### DIFF
--- a/src/examples/simple_deploy_aws.yml
+++ b/src/examples/simple_deploy_aws.yml
@@ -3,15 +3,15 @@ description: >
 usage:
   version: 2.1
   orbs:
-    serverless: circleci/serverless-framework@x.y
+    serverless-framework: circleci/serverless-framework@x.y
     aws-cli: circleci/aws-cli@x.y
   jobs:
     deploy:
-      executor: serverless/default
+      executor: serverless-framework/default
       steps:
         - checkout
         - aws-cli/setup
-        - serverless/setup:
+        - serverless-framework/setup:
             app-name: serverless-framework-orb
             org-name: circleci
         - run:

--- a/src/examples/test_and_deploy_node_aws.yml
+++ b/src/examples/test_and_deploy_node_aws.yml
@@ -3,16 +3,16 @@ description: >
 usage:
   version: 2.1
   orbs:
-    serverless: circleci/serverless-framework@x.y
+    serverless-framework: circleci/serverless-framework@x.y
     aws-cli: circleci/aws-cli@x.y
     node: circleci/node@x.y
   jobs:
     deploy:
-      executor: serverless/default
+      executor: serverless-framework/default
       steps:
         - checkout
         - aws-cli/setup
-        - serverless/setup:
+        - serverless-framework/setup:
             app-name: serverless-framework-orb
             org-name: circleci
         - run:


### PR DESCRIPTION
A customer wrote in with a build failure because when they were following the examples on the developer hub. The developer hub uses the orb name as the orb declaration, so it was causing a mismatch with the examples. 

```
orbs:
  serverless-framework: circleci/serverless-framework@1.0.1
```

This PR creates parity with the orb definition.