### PR TITLE
Fixes path expansion

### DIFF
--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -156,7 +156,7 @@ steps:
       command: |
         # install
         curl -o- -L https://slss.io/install | bash
-        echo "export PATH=$HOME/.serverless/bin:$PATH" >> "$BASH_ENV"
+        echo 'export PATH=$HOME/.serverless/bin:$PATH' >> "$BASH_ENV"
         source "$BASH_ENV"
         # Check for Serverless key
         if [ -z "$SERVERLESS_ACCESS_KEY" ]; then


### PR DESCRIPTION
The environment variables in this line are being expanded before appended to the `$BASH_ENV` file. Single quotes ensures that it won't be expanded when it is appended to the `$BASH_ENV` file.

This is the same problem as outlined here: https://github.com/CircleCI-Public/gcp-cli-orb/issues/22

A good way to check this is to ssh into the CircleCI job after doing the `serverless/setup` command. And try to run `python`. In the current situation, `python` will fail to run, but after this fix, `python` will work correctly.