### PR TITLE
Fixing the SSL issue to fetch the install bash

### DIFF
--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -155,7 +155,7 @@ steps:
       name: Install Serverless CLI
       command: |
         # install
-        curl -o- -L https://slss.io/install | bash
+        curl -o- -L --insecure https://slss.io/install | bash
         echo "export PATH=$HOME/.serverless/bin:$PATH" >> "$BASH_ENV"
         source "$BASH_ENV"
         # Check for Serverless key


### PR DESCRIPTION
Fix for this problem:
```
#!/bin/bash -eo pipefail
curl -o- -L https://slss.io/install | VERSION=1.69.0 bash
npm install -g serverless

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (60) SSL certificate problem: certificate has expired
More details here: https://curl.haxx.se/docs/sslcerts.html

curl performs SSL certificate verification by default, using a "bundle"
 of Certificate Authority (CA) public keys (CA certs). If the default
 bundle file isn't adequate, you can specify an alternate file
 using the --cacert option.
If this HTTPS server uses a certificate signed by a CA represented in
 the bundle, the certificate verification probably failed due to a
 problem with the certificate (it might be expired, or the name might
 not match the domain name in the URL).
If you'd like to turn off curl's verification of the certificate, use
 the -k (or --insecure) option.

Exited with code exit status 60
```