### PR TITLE
feat!: remove unused parameters

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -28,8 +28,6 @@ jobs:
           working_directory: "~/project/example"
       - serverless/setup:
           provider: AWS
-          app-name: serverless-framework-orb
-          org-name: circleci
       - run:
           name: Local invoke add function
           working_directory: "~/project/example"

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -6,14 +6,6 @@ parameters:
     type: enum
     enum: ["", "AWS", "azure", "tencent", "google", "knative", "alibaba", "cloudflare", "fn", "kubeless", "openwhisk", "spotinist"]
     default: "AWS"
-  org-name:
-    type: string
-    description: Connect to serverless.com dashboard. Provide the org name for this app.
-    default: ""
-  app-name:
-    type: string
-    description: Connect to serverless.com dashboard. Provide the name of this app.
-    default: ""
 steps:
   - run:
       name: Provider Check
@@ -22,7 +14,4 @@ steps:
       command: <<include(scripts/provider-check.sh)>>
   - run:
       name: Install Serverless CLI
-      environment:
-        SERVERLESS_ORB_ORG_NAME: << parameters.org-name >>
-        SERVERLESS_ORB_APP_NAME: << parameters.app-name >>
       command: <<include(scripts/install.sh)>>


### PR DESCRIPTION
The use of this parameter was removed in #27. This will now remove the parameter, which will cause jobs to fail which attempt to reference these parameters. The values needed are contained within the `serverless.yml` file.