### PR TITLE
feat: select version parameter

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -9,7 +9,22 @@ filters: &filters
   tags:
     only: /.*/
 jobs:
-  integration-test-1:
+  test-sls-install-versioned:
+    executor: serverless/default
+    environment:
+      SLS_DEBUG: "1"
+    steps:
+      - checkout
+      - aws-cli/setup
+      - serverless/setup:
+          version: 2.72.3
+          provider: AWS
+      - run:
+          name: Check SLS version
+          command: |
+            serverless --version | grep 2.72.3
+
+  test-sls-deploy:
     # Test within the default executor
     # - install the aws cli
     # - run serverless setup
@@ -41,7 +56,7 @@ workflows:
   test-deploy:
     jobs:
       # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
-      - integration-test-1:
+      - test-sls-deploy:
           filters: *filters
           context: CPE_ORBS_AWS
       - orb-tools/pack:
@@ -53,7 +68,7 @@ workflows:
           pub-type: production
           requires:
             - orb-tools/pack
-            - integration-test-1
+            - test-sls-deploy
           context: orb-publisher
           filters:
             branches:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -15,10 +15,9 @@ jobs:
       SLS_DEBUG: "1"
     steps:
       - checkout
-      - aws-cli/setup
       - serverless/setup:
           version: 2.72.3
-          provider: AWS
+          provider: ""
       - run:
           name: Check SLS version
           command: |
@@ -59,6 +58,8 @@ workflows:
       - test-sls-deploy:
           filters: *filters
           context: CPE_ORBS_AWS
+      - test-sls-install-versioned:
+          filters: *filters
       - orb-tools/pack:
           filters: *filters
       - orb-tools/publish:
@@ -69,6 +70,7 @@ workflows:
           requires:
             - orb-tools/pack
             - test-sls-deploy
+            - test-sls-install-versioned
           context: orb-publisher
           filters:
             branches:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -16,12 +16,12 @@ jobs:
     steps:
       - checkout
       - serverless/setup:
-          version: 2.72.3
+          version: 3.15.0
           provider: ""
       - run:
           name: Check SLS version
           command: |
-            serverless --version | grep 2.72.3
+            serverless --version | grep 3.15.0
 
   test-sls-deploy:
     # Test within the default executor

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -6,6 +6,10 @@ parameters:
     type: enum
     enum: ["", "AWS", "azure", "tencent", "google", "knative", "alibaba", "cloudflare", "fn", "kubeless", "openwhisk", "spotinist"]
     default: "AWS"
+  version:
+    type: string
+    description: Specify the version of the Serverless Framework CLI to install. By default, the latest version will be used.
+    default: ""
 steps:
   - run:
       name: Provider Check
@@ -14,4 +18,6 @@ steps:
       command: <<include(scripts/provider-check.sh)>>
   - run:
       name: Install Serverless CLI
+      environment:
+        ORB_PARAM_SERVERLESS_VERSION: <<parameters.version>>
       command: <<include(scripts/install.sh)>>

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -5,6 +5,7 @@ parameters:
   provider:
     type: enum
     enum: ["", "AWS", "azure", "tencent", "google", "knative", "alibaba", "cloudflare", "fn", "kubeless", "openwhisk", "spotinist"]
+    description: (Optional) Select a cloud provider to receive additional helpful error messages during your initial configuration if a misconfiguration is detected.
     default: "AWS"
   version:
     type: string

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-curl -o- -L https://slss.io/install | bash
+curl -o- -L https://slss.io/install | VERSION=$ORB_PARAM_SERVERLESS_VERSION bash
 echo "export PATH=$HOME/.serverless/bin:$PATH" >> "$BASH_ENV"
 # shellcheck disable=SC1090
 source "$BASH_ENV"

--- a/src/scripts/provider-check.sh
+++ b/src/scripts/provider-check.sh
@@ -94,6 +94,9 @@ openwhisk_Check () {
 spotinist_Check () {
   output_Provider_Selected "Spotinist"
 }
+other_Check () {
+  output_Provider_Selected "Other"
+}
 ###
 # Call provider based on parameter
 ###


### PR DESCRIPTION
This is a re-implement of #25.
Thank you to the original author. We wanted to refactor the orb and quickly release a major change with some upgrades without needing to ask contributors to make changes.

## Feat
This PR adds a parameter to set the version of the serverless framework CLI to be installed. A new unit test was added to verify the install version.

## Fix
This PR also includes a small fix for an issue encountered during testing. No Cloud Provider is needed to simply install the CLI, so in testing the `provider` was set to a blank string (which is a valid enum). This selection had not yet been accounted for. Added a simple echo statement to show that no option was selected rather than error.