### PR TITLE
chore: update executor patch and example versions

### DIFF
--- a/src/examples/simple_deploy_aws.yml
+++ b/src/examples/simple_deploy_aws.yml
@@ -3,17 +3,15 @@ description: >
 usage:
   version: 2.1
   orbs:
-    serverless-framework: circleci/serverless-framework@x.y
-    aws-cli: circleci/aws-cli@x.y
+    serverless-framework: circleci/serverless-framework@2.0
+    aws-cli: circleci/aws-cli@3.1
   jobs:
     deploy:
       executor: serverless-framework/default
       steps:
         - checkout
         - aws-cli/setup
-        - serverless-framework/setup:
-            app-name: serverless-framework-orb
-            org-name: circleci
+        - serverless-framework/setup
         - run:
             name: deploy
             command: serverless deploy -v

--- a/src/examples/test_and_deploy_node_aws.yml
+++ b/src/examples/test_and_deploy_node_aws.yml
@@ -3,18 +3,16 @@ description: >
 usage:
   version: 2.1
   orbs:
-    serverless-framework: circleci/serverless-framework@x.y
-    aws-cli: circleci/aws-cli@x.y
-    node: circleci/node@x.y
+    serverless-framework: circleci/serverless-framework@2.0
+    aws-cli: circleci/aws-cli@3.1
+    node: circleci/node@5.0.2
   jobs:
     deploy:
       executor: serverless-framework/default
       steps:
         - checkout
         - aws-cli/setup
-        - serverless-framework/setup:
-            app-name: serverless-framework-orb
-            org-name: circleci
+        - serverless-framework/setup
         - run:
             name: deploy
             command: serverless deploy -v
@@ -22,7 +20,7 @@ usage:
     deploy:
       jobs:
         - node/test:
-            version: "13.11.0"
+            version: "16.14.2"
         - deploy:
             requires:
               - node/test

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -4,7 +4,7 @@ docker:
   - image: 'cimg/python:<<parameters.python-version>>'
 parameters:
   python-version:
-    default: "3.8-node"
+    default: "3.10-node"
     description: >
       Select your python version or any of the available tags here:
       https://hub.docker.com/r/cimg/python.


### PR DESCRIPTION
# Changes
- Update the default executor to latest python patch
    - The node version is unchanged, v16.14.2
- Update the usage examples to reflect the next update (2.0)
    - Remove the no-longer-used parameters on the setup command
    - Update the showcased orb versions