### PR TITLE
feat: set download mirror location default to us

### DIFF
--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -18,5 +18,5 @@ steps:
       name: Install Serverless CLI
       environment:
         ORB_PARAM_SERVERLESS_VERSION: <<parameters.version>>
-        ORB_PARAM_MIRROR: <<parameters.mirror>
+        ORB_PARAM_MIRROR: <<parameters.mirror>>
       command: <<include(scripts/install.sh)>>

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -6,9 +6,17 @@ parameters:
     type: string
     description: Specify the version of the Serverless Framework CLI to install. By default, the latest version will be used.
     default: ""
+  mirror:
+    type: enum
+    enum:
+      - us
+      - cn
+    default: us
+    description: Select the geo-location for the download mirror. By default the value will be `us`, do not change if on CircleCI Cloud. Switch to `cn` for the China hosted mirror.
 steps:
   - run:
       name: Install Serverless CLI
       environment:
         ORB_PARAM_SERVERLESS_VERSION: <<parameters.version>>
+        ORB_PARAM_MIRROR: <<parameters.mirror>
       command: <<include(scripts/install.sh)>>

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export export SLS_SCRIPT_URL="https://sls-standalone-sv-1300963013.cos.na-siliconvalley.myqcloud.com/install.sh"
+export SLS_SCRIPT_URL="https://sls-standalone-sv-1300963013.cos.na-siliconvalley.myqcloud.com/install.sh"
 SLS_GEO_LOCATION=us
 if [ "$ORB_PARAM_MIRROR" = "cn" ]; then
   export SLS_SCRIPT_URL="https://sls-standalone-1300963013.cos.ap-shanghai.myqcloud.com/install.sh"

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
-curl -o- -L https://slss.io/install | VERSION=$ORB_PARAM_SERVERLESS_VERSION bash
+export export SLS_SCRIPT_URL="https://sls-standalone-sv-1300963013.cos.na-siliconvalley.myqcloud.com/install.sh"
+SLS_GEO_LOCATION=us
+if [ "$ORB_PARAM_MIRROR" = "cn"]; then
+  export SLS_SCRIPT_URL="https://sls-standalone-1300963013.cos.ap-shanghai.myqcloud.com/install.sh"
+  export SLS_GEO_LOCATION=cn
+fi
+curl -o- -L "$SLS_SCRIPT_URL" | VERSION=$ORB_PARAM_SERVERLESS_VERSION bash
 # shellcheck disable=SC2016
 echo 'export PATH=$HOME/.serverless/bin:$PATH' >> "$BASH_ENV"
 # shellcheck disable=SC1090

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 export export SLS_SCRIPT_URL="https://sls-standalone-sv-1300963013.cos.na-siliconvalley.myqcloud.com/install.sh"
 SLS_GEO_LOCATION=us
-if [ "$ORB_PARAM_MIRROR" = "cn"]; then
+if [ "$ORB_PARAM_MIRROR" = "cn" ]; then
   export SLS_SCRIPT_URL="https://sls-standalone-1300963013.cos.ap-shanghai.myqcloud.com/install.sh"
   export SLS_GEO_LOCATION=cn
 fi


### PR DESCRIPTION
# Changes

Added a new parameter `mirror` to the `setup` command. By default this changes the download mirror to the `US` hosted mirror, but can be reconfigured to use the `CN` mirror in the event a user is on CircleCI Server or using CircleCI Runner.

# Resolves
 - #23 
 - #15 