### PR TITLE
fix: switch the mirror selection responsibility to serverless

### DIFF
--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-export SLS_SCRIPT_URL="https://sls-standalone-sv-1300963013.cos.na-siliconvalley.myqcloud.com/install.sh"
-SLS_GEO_LOCATION=us
-if [ "$ORB_PARAM_MIRROR" = "cn" ]; then
-  export SLS_SCRIPT_URL="https://sls-standalone-1300963013.cos.ap-shanghai.myqcloud.com/install.sh"
-  export SLS_GEO_LOCATION=cn
-fi
-curl -o- -L "$SLS_SCRIPT_URL" | VERSION=$ORB_PARAM_SERVERLESS_VERSION bash
+
+[ "$ORB_PARAM_MIRROR" = "cn" ] && locale=cn
+[ "$ORB_PARAM_MIRROR" = "us" ] && locale=us
+
+# Let Serverless handle mirror selection.
+curl -o- -L https://slss.io/install | VERSION="$ORB_PARAM_SERVERLESS_VERSION" SLS_GEO_LOCATION="$locale" bash
+
 # shellcheck disable=SC2016
 echo 'export PATH=$HOME/.serverless/bin:$PATH' >> "$BASH_ENV"
 # shellcheck disable=SC1090


### PR DESCRIPTION
## Motivation

- Closes #40 

## Changes

- Shifts the responsibility of mirror selection to serverless. 

For whatever reason, the cloud provider we were getting the script from is throwing errors. So, instead of getting it from them, we will leave Serverles pick what is best based on the `mirror` parameter. They have some logic around it [here](https://github.com/serverless/serverless/blob/main/scripts/pkg/install.sh#L69):

```bash
if [[ $IS_IN_CHINA == "1" ]]
then
	# In China download from location in China (Github API download is slow and times out)
	BINARY_URL=https://sls-standalone-sv-1300963013.cos.na-siliconvalley.myqcloud.com/$TAG/serverless-$PLATFORM-$ARCH
else
	BINARY_URL=https://github.com/serverless/serverless/releases/download/$TAG/serverless-$PLATFORM-$ARCH
fi
```

