### PR TITLE
[PIE-44] Bump default Python version to 3.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ workflows:
       - orb-tools/publish:
           orb-name: circleci/serverless-framework
           vcs-type: << pipeline.project.type >>
+          enable-pr-comment: false
           github-token: GHI_TOKEN
           requires:
             [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -65,6 +65,7 @@ workflows:
       - orb-tools/publish:
           orb-name: circleci/serverless-framework
           vcs-type: << pipeline.project.type >>
+          enable-pr-comment: false
           github-token: GHI_TOKEN
           pub-type: production
           requires:

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -4,7 +4,7 @@ docker:
   - image: 'cimg/python:<<parameters.python-version>>'
 parameters:
   python-version:
-    default: "3.10-node"
+    default: "3.13-node"
     description: >
       Select your python version or any of the available tags here:
       https://hub.docker.com/r/cimg/python.


### PR DESCRIPTION
### Breaking Change

Default executor image updated to `cimg/python:3.13-node`
The default Docker image for the `serverless-framework/default` executor has been updated from the `cimg/python:3.10-node` tag to `cimg/python:3.13-node`.

If you need to continue using the previous Python version, you can override the `python-version` parameter on the executor.

If you use the built-in executor directly in a job:

```yaml
version: 2.1
orbs:
  serverless-framework: circleci/serverless-framework@x.x.x

jobs:
  deploy:
    executor:
      name: serverless-framework/default
      python-version: "3.12-node"  # pin to your required version
    steps:
      - checkout
      - serverless-framework/setup
      - run: serverless deploy -v
```

If you use a job provided by this orb that accepts an executor parameter:

```yaml
version: 2.1
orbs:
  serverless-framework: circleci/serverless-framework@x.x.x

workflows:
  deploy:
    jobs:
      - serverless-framework/some-job:
          executor:
            name: serverless-framework/default
            python-version: "3.12-node"
```
Any tag available on [cimg/python on Docker Hub](https://hub.docker.com/r/cimg/python) is valid. For example `3.11-node`, `3.12-node`, or a specific patch like `3.12.7-node`.